### PR TITLE
Array#nitems => Array#count

### DIFF
--- a/lib/prawn/graph/base.rb
+++ b/lib/prawn/graph/base.rb
@@ -210,7 +210,7 @@ module Prawn
       alias calculate_y_axis_centre_point calculate_y_axis_center_point
 
       def calculate_plot_spacing
-        (@grid.width / @values.nitems)
+        (@grid.width / @values.count)
       end
 
       def calculate_bar_width

--- a/lib/prawn/graph/themes.rb
+++ b/lib/prawn/graph/themes.rb
@@ -100,7 +100,7 @@ module Prawn
             return @colours[0]
           end
           @current_colour += 1
-          @current_colour = 0 if @current_colour == @colours.nitems
+          @current_colour = 0 if @current_colour == @colours.count
           @colours[@current_colour]
         end
         alias next_color next_colour


### PR DESCRIPTION
Array#nitems is not supported in Ruby 1.9. Array#count is supported in both Ruby 1.8.7 and Ruby 1.9.
