### PR TITLE
Fix y-axis labels showing series max for all points

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ before_install: gem install bundler -v 1.11.2
 addons:
     code_climate:
         repo_token: 9646aae52d1d1670d545c46bd94f5d86b92d516c5e3cb9890fcef62acc3a34b6
+after_script: codeclimate-test-reporter

--- a/lib/prawn/graph/chart_components/series_renderer.rb
+++ b/lib/prawn/graph/chart_components/series_renderer.rb
@@ -68,7 +68,7 @@ module Prawn
         def add_y_axis_label(value)
           unless value.zero?
             y = (point_height_percentage(value) * @plot_area_height)
-            prawn.text_box "#{max}", at: [-14, y], height: 5, overflow: :shrink_to_fit, width: 12, valign: :bottom, align: :right 
+            prawn.text_box "#{value}", at: [-14, y], height: 5, overflow: :shrink_to_fit, width: 12, valign: :bottom, align: :right 
           end
         end
 

--- a/lib/prawn/graph/version.rb
+++ b/lib/prawn/graph/version.rb
@@ -1,5 +1,5 @@
 module Prawn
   module Graph
-    VERSION = "1.1.0.pre"
+    VERSION = "1.0.4"
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
 require 'simplecov'
 SimpleCov.start
 


### PR DESCRIPTION
This was caused by the SeriesRenderer always using the max as the label values when drawing the y-axis.

I tested this change with both of the examples provided in the related issue. Here is a before and after using the example in the README.

Before:
![image](https://cloud.githubusercontent.com/assets/8890714/20329810/1400a70a-ab60-11e6-8b07-a6f567a6d659.png)

After:
![image](https://cloud.githubusercontent.com/assets/8890714/20329782/eed62a4a-ab5f-11e6-9705-3df415027d6a.png)
