### PR TITLE
Fix integration with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ before_install: gem install bundler -v 1.11.2
 addons:
     code_climate:
         repo_token: 9646aae52d1d1670d545c46bd94f5d86b92d516c5e3cb9890fcef62acc3a34b6
+after_script: codeclimate-test-reporter

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
 require 'simplecov'
 SimpleCov.start
 


### PR DESCRIPTION
This will fix an issue caused by deprecation of the CodeClimate::TestReporter in the 1.0 release of codeclimate-test-reporter gem. Once this pull request is merged in, builds should no longer fail (unless they are actually meant to).