### PR TITLE
Fix y position on BarChartRenderer.

### DIFF
--- a/lib/prawn/graph/chart_components/bar_chart_renderer.rb
+++ b/lib/prawn/graph/chart_components/bar_chart_renderer.rb
@@ -1,8 +1,8 @@
 module Prawn
   module Graph
     module ChartComponents
-      # The Prawn::Graph::ChartComponents::BarChartRenderer is used to plot one or more bar charts 
-      # in a sensible way on a a Prawn::Graph::ChartComponents::Canvas and its associated 
+      # The Prawn::Graph::ChartComponents::BarChartRenderer is used to plot one or more bar charts
+      # in a sensible way on a a Prawn::Graph::ChartComponents::Canvas and its associated
       # Prawn::Document.
       #
       class BarChartRenderer < SeriesRenderer
@@ -41,8 +41,8 @@ module Prawn
 
         def render_the_chart
           prawn.bounding_box [@graph_area.point[0] + 5, @graph_area.point[1] - 20], width: @plot_area_width, height: @plot_area_height do
-         
-            prawn.save_graphics_state do  
+
+            prawn.save_graphics_state do
               num_points        = @series[0].size
               width_per_point   = (@plot_area_width / num_points)
               width             = (((width_per_point * 0.9) / @series.size).round(2)).to_f
@@ -60,7 +60,7 @@ module Prawn
                   starting = (prawn.bounds.left + (point * width_per_point))
 
                   x_position = ( (starting + (series_offset * width) ).to_f - (width / 2.0))
-                  y_position = ((point_height_percentage(@series[series_index].values[point]) * @plot_area_height) - 5).to_f
+                  y_position = (point_height_percentage(@series[series_index].values[point]) * @plot_area_height).to_f
 
                   prawn.fill_and_stroke_line([ x_position ,0], [x_position ,y_position]) unless @series[series_index].values[point].zero?
 
@@ -76,7 +76,7 @@ module Prawn
           end
         end
 
-        def max 
+        def max
           @series.collect(&:max).max || 0
         end
 

--- a/lib/prawn/graph/chart_components/bar_chart_renderer.rb
+++ b/lib/prawn/graph/chart_components/bar_chart_renderer.rb
@@ -66,6 +66,15 @@ module Prawn
 
                   prawn.fill_and_stroke_line([ x_position ,0], [x_position ,y_position]) unless @series[series_index].values[point].zero?
 
+                  prawn.fill_color = "000000"
+                  prawn.text_box "#{@series[series_index].values[point]}",
+                                 at: [x_position - 6, y_position + 10],
+                                 height: 5,
+                                 overflow: :shrink_to_fit,
+                                 width: 12,
+                                 valign: :bottom,
+                                 align: :right
+
                   mark_average_line(series_index)
                   max_marked = mark_maximum_point(series_index, point, max_marked, x_position, y_position)
                   min_marked = mark_minimum_point(series_index, point, min_marked, x_position, y_position)
@@ -76,6 +85,16 @@ module Prawn
             end
             render_axes
           end
+        end
+
+        def render_axes
+          prawn.stroke_color  = @canvas.theme.axes
+          prawn.fill_color  = @canvas.theme.axes
+          prawn.stroke_horizontal_line(0, @plot_area_width, at: 0)
+          prawn.stroke_vertical_line(0, @plot_area_height, at: 0)
+          prawn.fill_and_stroke_ellipse [ 0,0], 1
+
+          add_x_axis_labels
         end
 
         def max

--- a/lib/prawn/graph/chart_components/bar_chart_renderer.rb
+++ b/lib/prawn/graph/chart_components/bar_chart_renderer.rb
@@ -48,6 +48,7 @@ module Prawn
               width             = (((width_per_point * 0.9) / @series.size).round(2)).to_f
               min_marked        = false
               max_marked        = false
+              min_height        = 2
 
               num_points.times do |point|
 
@@ -60,7 +61,8 @@ module Prawn
                   starting = (prawn.bounds.left + (point * width_per_point))
 
                   x_position = ( (starting + (series_offset * width) ).to_f - (width / 2.0))
-                  y_position = (point_height_percentage(@series[series_index].values[point]) * @plot_area_height).to_f
+                  proportional_height = (point_height_percentage(@series[series_index].values[point]) * @plot_area_height).to_f
+                  y_position = [proportional_height, min_height].max
 
                   prawn.fill_and_stroke_line([ x_position ,0], [x_position ,y_position]) unless @series[series_index].values[point].zero?
 

--- a/lib/prawn/graph/chart_components/bar_chart_renderer.rb
+++ b/lib/prawn/graph/chart_components/bar_chart_renderer.rb
@@ -77,11 +77,11 @@ module Prawn
         end
 
         def max
-          @series.collect(&:max).max || 0
+          @series.map(&:max).compact.max || 0
         end
 
         def min
-          @series.collect(&:min).min || 0
+          @series.map(&:min).compact.min || 0
         end
 
         def avg

--- a/lib/prawn/graph/chart_components/series_renderer.rb
+++ b/lib/prawn/graph/chart_components/series_renderer.rb
@@ -76,7 +76,8 @@ module Prawn
         # the series.
         #
         def point_height_percentage(value)
-          ((BigDecimal(value, 10)/BigDecimal(@canvas.series.collect(&:max).max, 10)) * BigDecimal(1)).round(2) rescue 0
+          result = ((BigDecimal(value, 10)/BigDecimal(@canvas.series.collect(&:max).max, 10)) * BigDecimal(1)).round(2) rescue 0
+          result.nan? ? 0 : result.to_f
         end
 
         def prawn


### PR DESCRIPTION
When the column value is less than 5 the chart uses a negative value to y_position for this bar

Before
<img width="818" alt="Screenshot 2024-08-30 at 14 06 55" src="https://github.com/user-attachments/assets/b5ab9614-9ed0-450d-8c1e-34fb5ec63f79">

After
<img width="796" alt="Screenshot 2024-08-30 at 14 08 27" src="https://github.com/user-attachments/assets/c9c79c00-e0e2-4005-a315-cc68730e7d3d">
